### PR TITLE
Added a country region-preferred request

### DIFF
--- a/SVGeocoder/SVGeocoder.h
+++ b/SVGeocoder/SVGeocoder.h
@@ -21,7 +21,8 @@
 @property (nonatomic, assign) id<SVGeocoderDelegate> delegate;
 
 - (SVGeocoder*)initWithCoordinate:(CLLocationCoordinate2D)coordinate;
-- (SVGeocoder*)initWithAddress:(NSString *)address inRegion:(MKCoordinateRegion)region;
+- (SVGeocoder*)initWithAddress:(NSString *)address withBounds:(MKCoordinateRegion)region;
+- (SVGeocoder*)initWithAddress:(NSString *)address inRegion:(NSString *)region;
 - (SVGeocoder*)initWithAddress:(NSString *)address;
 
 - (void)startAsynchronous;

--- a/SVGeocoder/SVGeocoder.m
+++ b/SVGeocoder/SVGeocoder.m
@@ -32,7 +32,7 @@
 	return self;
 }
 
-- (SVGeocoder*)initWithAddress:(NSString *)address inRegion:(MKCoordinateRegion)region {
+- (SVGeocoder*)initWithAddress:(NSString *)address withBounds:(MKCoordinateRegion)region {
 			
 	self.requestString = [NSString stringWithFormat:@"http://maps.googleapis.com/maps/api/geocode/json?address=%@&bounds=%f,%f|%f,%f&sensor=true", 
 						  address,
@@ -46,6 +46,16 @@
 	return self;
 }
 
+- (SVGeocoder*)initWithAddress:(NSString *)address inRegion:(NSString *)region {
+	
+	self.requestString = [NSString stringWithFormat:@"http://maps.googleapis.com/maps/api/geocode/json?address=%@&region=%@&sensor=true", 
+						  address,
+						  region];
+	
+	NSLog(@"SVGeocoder -> %@", self.requestString);
+	
+	return self;
+}
 
 - (SVGeocoder*)initWithAddress:(NSString*)address {
 	

--- a/SVGeocoder/SVPlacemark.m
+++ b/SVGeocoder/SVPlacemark.m
@@ -15,7 +15,7 @@
 
 - (id)initWithCoordinate:(CLLocationCoordinate2D)aCoordinate addressDictionary:(NSDictionary *)addressDictionary {
 	
-	if(self = [super initWithCoordinate:aCoordinate addressDictionary:addressDictionary])
+	if((self = [super initWithCoordinate:aCoordinate addressDictionary:addressDictionary]))
 		self.coordinate = aCoordinate;
 	
 	return self;


### PR DESCRIPTION
Added a method in SVGeocoder to allow us to search within a specified country region.

Sorry, I wasn't concerned about compatibility, so I made the inRegion: parameter reflect the API's use of 'region', which will of course break any existing use of that method ;)

-J
