### PR TITLE
Error Status Handling + "Querying" property + % encoding of "|"

### DIFF
--- a/SVGeocoder/SVGeocoder.h
+++ b/SVGeocoder/SVGeocoder.h
@@ -15,6 +15,13 @@
 
 #import "SVPlacemark.h"
 
+typedef enum {
+	SVGeocoderZeroResultsError = 1,
+	SVGeocoderOverQueryLimitError,
+	SVGeocoderRequestDeniedError,
+	SVGeocoderInvalidRequestError
+} SVGecoderError;
+
 @protocol SVGeocoderDelegate;
 
 @interface SVGeocoder : NSObject

--- a/SVGeocoder/SVGeocoder.m
+++ b/SVGeocoder/SVGeocoder.m
@@ -159,7 +159,35 @@
 		[self connection:connection didFailWithError:jsonError];
 		return;
 	}
-    
+	
+	NSString *status = [responseDict valueForKey:@"status"];
+	
+	// deal with error statuses by raising didFailWithError
+	
+	if ([status isEqualToString:@"ZERO_RESULTS"]) {
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderZeroResultsError userInfo:nil];
+		[self.delegate geocoder:self didFailWithError:error];
+		return;
+	}
+	
+	if ([status isEqualToString:@"OVER_QUERY_LIMIT"]) {
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderOverQueryLimitError userInfo:nil];
+		[self.delegate geocoder:self didFailWithError:error];
+		return;
+	}
+
+	if ([status isEqualToString:@"REQUEST_DENIED"]) {
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderRequestDeniedError userInfo:nil];
+		[self.delegate geocoder:self didFailWithError:error];
+		return;
+	}    
+	
+	if ([status isEqualToString:@"INVALID_REQUEST"]) {
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderInvalidRequestError userInfo:nil];
+		[self.delegate geocoder:self didFailWithError:error];
+		return;
+	}
+	
     for(NSDictionary *placemarkDict in resultsArray) {
 	
         NSDictionary *addressDict = [placemarkDict valueForKey:@"address_components"];


### PR DESCRIPTION
Adds "|" to percent encoding of URL parameters when using geocoder with a specific bounds.

Adds a Querying property that shows the status of the geocoder if it is currently querying Google for a geolocation request.

Finally, adds checking of the status returned by Google to correctly fire on statuses other than "OK".
