### PR TITLE
Opps. Forgotten to added these to the initial pull request.

### DIFF
--- a/SVGeocoder/SVGeocoder.m
+++ b/SVGeocoder/SVGeocoder.m
@@ -169,25 +169,33 @@
 	// deal with error statuses by raising didFailWithError
 	
 	if ([status isEqualToString:@"ZERO_RESULTS"]) {
-		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderZeroResultsError userInfo:nil];
+		NSDictionary *userinfo = [NSDictionary dictionaryWithObjectsAndKeys:@"Zero results returned", NSLocalizedDescriptionKey, nil];
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderZeroResultsError userInfo:userinfo];
+		
 		[self.delegate geocoder:self didFailWithError:error];
 		return;
 	}
 	
 	if ([status isEqualToString:@"OVER_QUERY_LIMIT"]) {
-		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderOverQueryLimitError userInfo:nil];
+		NSDictionary *userinfo = [NSDictionary dictionaryWithObjectsAndKeys:@"Currently rate limited. Too many queries in a short time. (Over Quota)", NSLocalizedDescriptionKey, nil];
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderOverQueryLimitError userInfo:userinfo];
+
 		[self.delegate geocoder:self didFailWithError:error];
 		return;
 	}
 
 	if ([status isEqualToString:@"REQUEST_DENIED"]) {
-		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderRequestDeniedError userInfo:nil];
+		NSDictionary *userinfo = [NSDictionary dictionaryWithObjectsAndKeys:@"Request was denied. Did you remember to add the \"sensor\" parameter?", NSLocalizedDescriptionKey, nil];
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderRequestDeniedError userInfo:userinfo];
+
 		[self.delegate geocoder:self didFailWithError:error];
 		return;
 	}    
 	
 	if ([status isEqualToString:@"INVALID_REQUEST"]) {
-		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderInvalidRequestError userInfo:nil];
+		NSDictionary *userinfo = [NSDictionary dictionaryWithObjectsAndKeys:@"The request was invalid. Was the \"address\" or \"latlng\" missing?", NSLocalizedDescriptionKey, nil];
+		NSError *error = [NSError errorWithDomain:@"SVGeocoderErrorDomain" code:SVGeocoderInvalidRequestError userInfo:userinfo];
+
 		[self.delegate geocoder:self didFailWithError:error];
 		return;
 	}


### PR DESCRIPTION
Centralize all encoding of URL parameters to % escaped representation.

Removed check if results array is empty so that the proper status code will return the proper NSError.
