### PR TITLE
Region/bounds support

### DIFF
--- a/SVGeocoder/SVGeocoder.m
+++ b/SVGeocoder/SVGeocoder.m
@@ -316,18 +316,16 @@ typedef NSUInteger SVGeocoderRequestState;
                     CLLocationDegrees lng = [[coordinateDict valueForKey:@"lng"] floatValue];
                     CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(lat, lng);
                     
-                    // Set the region radius as half the diagonal of the bounds
                     NSDictionary *northEastDict = [boundsDict objectForKey:@"northeast"];
                     NSDictionary *southWestDict = [boundsDict objectForKey:@"southwest"];
                     CLLocationDegrees northEastLatitude = [[northEastDict objectForKey:@"lat"] floatValue];
-                    CLLocationDegrees northEastLongitude = [[northEastDict objectForKey:@"lng"] floatValue];
-                    CLLocation *northEastLocation = [[CLLocation alloc] initWithLatitude:northEastLatitude longitude:northEastLongitude];
                     CLLocationDegrees southWestLatitude = [[southWestDict objectForKey:@"lat"] floatValue];
+                    CLLocationDegrees latitudeDelta = fabs(northEastLatitude - southWestLatitude);
+                    CLLocationDegrees northEastLongitude = [[northEastDict objectForKey:@"lng"] floatValue];
                     CLLocationDegrees southWestLongitude = [[southWestDict objectForKey:@"lng"] floatValue];
-                    CLLocation *southWestLocation = [[CLLocation alloc] initWithLatitude:southWestLatitude longitude:southWestLongitude];                    
-                    CLLocationDistance radius = [northEastLocation distanceFromLocation:southWestLocation]/2;
-                    [northEastLocation release];
-                    [southWestLocation release];
+                    CLLocationDegrees longitudeDelta = fabs(northEastLongitude - southWestLongitude);
+                    MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
+                    MKCoordinateRegion region = MKCoordinateRegionMake(coordinate, span);
                     
                     NSMutableDictionary *formattedAddressDict = [[NSMutableDictionary alloc] init];
                     NSMutableArray *streetAddressComponents = [NSMutableArray arrayWithCapacity:2];
@@ -362,11 +360,8 @@ typedef NSUInteger SVGeocoderRequestState;
                     if([streetAddressComponents count] > 0)
                         [formattedAddressDict setValue:[streetAddressComponents componentsJoinedByString:@" "] forKey:(NSString*)kABPersonAddressStreetKey];
                     
-                    CLRegion *region = [[CLRegion alloc] initCircularRegionWithCenter:coordinate radius:radius identifier:[placemarkDict objectForKey:@"formatted_address"]];
-                    
                     SVPlacemark *placemark = [[SVPlacemark alloc] initWithRegion:region addressDictionary:formattedAddressDict];
                     [formattedAddressDict release];
-                    [region release];
                     
                     placemark.formattedAddress = [placemarkDict objectForKey:@"formatted_address"];
                     

--- a/SVGeocoder/SVPlacemark.h
+++ b/SVGeocoder/SVPlacemark.h
@@ -16,9 +16,9 @@
 }
 
 @property (nonatomic, readwrite) CLLocationCoordinate2D coordinate;
-@property (nonatomic, copy) CLRegion *region;
+@property (nonatomic, readwrite) MKCoordinateRegion region;
 @property (nonatomic, retain) NSString * formattedAddress;
 
-- (id)initWithRegion:(CLRegion *)region addressDictionary:(NSDictionary *)addressDictionary;
+- (id)initWithRegion:(MKCoordinateRegion)region addressDictionary:(NSDictionary *)addressDictionary;
 
 @end

--- a/SVGeocoder/SVPlacemark.m
+++ b/SVGeocoder/SVPlacemark.m
@@ -30,7 +30,7 @@
 	return self;
 }
 
-- (id)initWithRegion:(CLRegion *)region addressDictionary:(NSDictionary *)addressDictionary {
+- (id)initWithRegion:(MKCoordinateRegion)region addressDictionary:(NSDictionary *)addressDictionary {
     
     if ((self = [super initWithCoordinate:region.center addressDictionary:addressDictionary])) {
         self.coordinate = region.center;
@@ -38,11 +38,6 @@
     }
     
     return self;
-}
-
-- (CLRegion *)region
-{
-    return _region;
 }
 
 - (NSString*)description {


### PR DESCRIPTION
The original SVPlacemark only contains the latitude and longitude of the location found. When displaying the item that was found in a MKMapView, we need to choose a good zoom level in order to present this item nicely. For example, think about the zoom level for a street and for a state. The state is obviously much larger than the street then we need to zoom out.

Now the region property of a SVPlacemark can be assigned directly to the mapView with the `-[MKMapView setRegion:animated:]` method, and it should center around the object and zoom properly.
