### PR TITLE
implementation of component filtering

### DIFF
--- a/SVGeocoder/SVGeocoder.h
+++ b/SVGeocoder/SVGeocoder.h
@@ -13,6 +13,12 @@
 
 #import "SVPlacemark.h"
 
+#define SVGeocoderComponentRoute     @"route"
+#define SVGeocoderComponentLocality  @"locality"
+#define SVGeocoderAdministrativeArea @"administrative_area"
+#define SVGeocoderPostalCode         @"postal_code"
+#define SVGeocoderCountry            @"country"
+
 typedef enum {
 	SVGeocoderZeroResultsError = 1,
 	SVGeocoderOverQueryLimitError,
@@ -28,11 +34,16 @@ typedef void (^SVGeocoderCompletionHandler)(NSArray *placemarks, NSHTTPURLRespon
 
 + (SVGeocoder*)geocode:(NSString *)address completion:(SVGeocoderCompletionHandler)block;
 + (SVGeocoder*)geocode:(NSString *)address region:(CLRegion *)region completion:(SVGeocoderCompletionHandler)block;
++ (SVGeocoder*)geocode:(NSString *)address components:(NSDictionary *)components completion:(SVGeocoderCompletionHandler)block;
++ (SVGeocoder*)geocode:(NSString *)address region:(CLRegion *)region components:(NSDictionary *)components completion:(SVGeocoderCompletionHandler)block;
 
 + (SVGeocoder*)reverseGeocode:(CLLocationCoordinate2D)coordinate completion:(SVGeocoderCompletionHandler)block;
 
 - (SVGeocoder*)initWithAddress:(NSString *)address completion:(SVGeocoderCompletionHandler)block;
 - (SVGeocoder*)initWithAddress:(NSString *)address region:(CLRegion *)region completion:(SVGeocoderCompletionHandler)block;
+- (SVGeocoder*)initWithAddress:(NSString *)address components:(NSDictionary *)components completion:(SVGeocoderCompletionHandler)block;
+- (SVGeocoder*)initWithAddress:(NSString *)address region:(CLRegion *)region components:(NSDictionary *)components completion:(SVGeocoderCompletionHandler)block;
+
 
 - (SVGeocoder*)initWithCoordinate:(CLLocationCoordinate2D)coordinate completion:(SVGeocoderCompletionHandler)block;
 


### PR DESCRIPTION
Components filtering is really important feature of Google Geocoder API, because bounds are sometimes insufficient. For example query with London bounds:

```
http://maps.googleapis.com/maps/api/geocode/json?bounds=51.417512%2C-0.271765%7C51.597274%2C0.016299&language=en&address=New%20York&sensor=true
```

will return New York, USA.
It happens because bounds are just suggestion.

The solution of this issue is using component filtering. Query below:

```
http://maps.googleapis.com/maps/api/geocode/json?language=en&bounds=51.417512%2C-0.271765%7C51.597274%2C0.016299&components=locality%3ALondon%7Ccountry%3AGB&address=New%20York&sensor=true
```

will return expected results.

I've pushed implementation of constructors and class methods allowing component filtering.

Example of usage:

```
CLLocationCoordinate2D londonCenter =
CLLocationCoordinate2DMake(51.507393, -0.127733);


CLRegion* region = [[CLRegion alloc]
                    initCircularRegionWithCenter:londonCenter
                    radius:20000
                    identifier:@"London Region"];

id components = @{SVGeocoderComponentLocality: @"London",
                  SVGeocoderCountry: @"GB"};

[SVGeocoder geocode:@"New York" region:region components:components completion:^(NSArray *placemarks, NSHTTPURLResponse *urlResponse, NSError *error) {
    [placemarks enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
        NSLog(@"%@", obj);
    }];
}];
```

Regards,
Michał
