### PR TITLE
Adds support for manually specifying rectangular regions, and for the "partial_match" field

### DIFF
--- a/SVGeocoder/SVGeocoder.h
+++ b/SVGeocoder/SVGeocoder.h
@@ -21,6 +21,12 @@ typedef enum {
     SVGeocoderJSONParsingError
 } SVGecoderError;
 
+typedef struct {
+	CLLocationCoordinate2D southwest;
+	CLLocationCoordinate2D northeast;
+} SVGeocoderRectangularRegion;
+
+SVGeocoderRectangularRegion SVGeocoderRectangularRegionMake(CLLocationCoordinate2D southwest, CLLocationCoordinate2D northeast);
 
 typedef void (^SVGeocoderCompletionHandler)(NSArray *placemarks, NSHTTPURLResponse *urlResponse, NSError *error);
 
@@ -28,11 +34,13 @@ typedef void (^SVGeocoderCompletionHandler)(NSArray *placemarks, NSHTTPURLRespon
 
 + (SVGeocoder*)geocode:(NSString *)address completion:(SVGeocoderCompletionHandler)block;
 + (SVGeocoder*)geocode:(NSString *)address region:(CLRegion *)region completion:(SVGeocoderCompletionHandler)block;
++ (SVGeocoder*)geocode:(NSString *)address rectangularRegion:(SVGeocoderRectangularRegion)region completion:(SVGeocoderCompletionHandler)block;
 
 + (SVGeocoder*)reverseGeocode:(CLLocationCoordinate2D)coordinate completion:(SVGeocoderCompletionHandler)block;
 
 - (SVGeocoder*)initWithAddress:(NSString *)address completion:(SVGeocoderCompletionHandler)block;
 - (SVGeocoder*)initWithAddress:(NSString *)address region:(CLRegion *)region completion:(SVGeocoderCompletionHandler)block;
+- (SVGeocoder*)initWithAddress:(NSString *)address rectangularRegion:(SVGeocoderRectangularRegion)region completion:(SVGeocoderCompletionHandler)block;
 
 - (SVGeocoder*)initWithCoordinate:(CLLocationCoordinate2D)coordinate completion:(SVGeocoderCompletionHandler)block;
 

--- a/SVGeocoder/SVGeocoder.m
+++ b/SVGeocoder/SVGeocoder.m
@@ -21,6 +21,12 @@ enum {
 
 typedef NSUInteger SVGeocoderState;
 
+SVGeocoderRectangularRegion SVGeocoderRectangularRegionMake(CLLocationCoordinate2D southwest, CLLocationCoordinate2D northeast) {
+  SVGeocoderRectangularRegion rectReg;
+  rectReg.southwest = southwest;
+  rectReg.northeast = northeast;
+  return rectReg;
+}
 
 @interface NSString (URLEncoding)
 - (NSString*)encodedURLParameterString;
@@ -79,6 +85,12 @@ typedef NSUInteger SVGeocoderState;
     return geocoder;
 }
 
++ (SVGeocoder *)geocode:(NSString *)address rectangularRegion:(SVGeocoderRectangularRegion)region completion:(SVGeocoderCompletionHandler)block {
+    SVGeocoder *geocoder = [[self alloc] initWithAddress:address rectangularRegion:region completion:block];
+    [geocoder start];
+    return geocoder;
+}
+
 + (SVGeocoder *)reverseGeocode:(CLLocationCoordinate2D)coordinate completion:(SVGeocoderCompletionHandler)block {
     SVGeocoder *geocoder = [[self alloc] initWithCoordinate:coordinate completion:block];
     [geocoder start];
@@ -114,6 +126,19 @@ typedef NSUInteger SVGeocoderState;
                                             coordinateRegion.center.longitude+(coordinateRegion.span.longitudeDelta/2.0)], @"bounds", nil];
     
     return [self initWithParameters:parameters completion:block];
+}
+
+
+- (SVGeocoder*)initWithAddress:(NSString *)address rectangularRegion:(SVGeocoderRectangularRegion)region completion:(SVGeocoderCompletionHandler)block {
+  NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                       address, @"address",
+                                       [NSString stringWithFormat:@"%f,%f|%f,%f",
+                                            region.southwest.latitude,
+                                            region.southwest.longitude,
+                                            region.northeast.latitude,
+                                            region.northeast.longitude], @"bounds", nil];
+  
+  return [self initWithParameters:parameters completion:block];
 }
 
 

--- a/SVGeocoder/SVPlacemark.h
+++ b/SVGeocoder/SVPlacemark.h
@@ -31,5 +31,6 @@
 @property (nonatomic, readonly) CLLocationCoordinate2D coordinate;
 @property (nonatomic, readonly) MKCoordinateRegion region;
 @property (nonatomic, strong, readonly) CLLocation *location;
+@property (nonatomic, readonly) BOOL partialMatch;
 
 @end

--- a/SVGeocoder/SVPlacemark.m
+++ b/SVGeocoder/SVPlacemark.m
@@ -27,6 +27,7 @@
 @property (nonatomic, readwrite) CLLocationCoordinate2D coordinate;
 @property (nonatomic, readwrite) MKCoordinateRegion region;
 @property (nonatomic, strong, readwrite) CLLocation *location;
+@property (nonatomic, readwrite) BOOL partialMatch;
 
 @end
 
@@ -93,6 +94,8 @@
         CLLocationDegrees longitudeDelta = fabs(northEastLongitude - southWestLongitude);
         MKCoordinateSpan span = MKCoordinateSpanMake(latitudeDelta, longitudeDelta);
         self.region = MKCoordinateRegionMake(self.location.coordinate, span);
+      
+        self.partialMatch = [result objectForKey:@"partial_match"];
     }
     
     return self;


### PR DESCRIPTION
For the "bounds" parameter (viewport biasing).  Could have been implemented as 2 parameters to the geocode/initWithAddress methods, but this seemed somewhat cleaner.

Also now supports the "partial_match" field in the result JSON, and sets a BOOL property in SVPlacemark.
